### PR TITLE
fix(plausible): add proxy to connect Plausible to Vercel+Next.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,12 @@
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 })
+const { withPlausibleProxy } = require('next-plausible')
 
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
+const nextConfig = withPlausibleProxy()({
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'md', 'mdx'],
   webpack: (config, { dev, isServer }) => {
@@ -38,6 +39,6 @@ const nextConfig = {
 
     return config
   },
-}
+})
 
 module.exports = withBundleAnalyzer(nextConfig)


### PR DESCRIPTION
Fixes #240 

Resources:
https://plausible.io/docs/proxy/guides/nextjs